### PR TITLE
Update license for consistency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
-MIT License
+Copyright (c) IBM Corp. 2012,2018. All Rights Reserved.
+Node module: loopback-connector-zosconnectee
+This project is licensed under the MIT License, full text below.
 
-Copyright (c) 2017 StrongLoop
+--------
+
+MIT license
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +13,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -1,2 +1,7 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-zosconnectee
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 module.exports = require('./lib/zosconnectee-connector.js');
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-zosconnectee
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 var util = require('util');

--- a/lib/zosconnectee-connector.js
+++ b/lib/zosconnectee-connector.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-connector-zosconnectee
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 var Connector = require('loopback-connector').Connector;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-connector-zosconnectee"
   },
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {


### PR DESCRIPTION
### Description

- Update the license to make "IBM copyright" instead of "StrongLoop copyright" for being consistent with the other modules
- update package.json to the right value for `slt copyright` command to run properly
- run `slt copyright` to update the copyright header of source code


Related to: strongloop-internal/scrum-apex#382