### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You may further edit the generated template file located in your LoopBack applic
 ### Module Long Term Support Policy
 This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy, with the following End Of Life (EOL) dates:
 
- | Module Version   | Release Date | Minimum EOL | EOL With     | Status  |
- |------------------|--------------|-------------|--------------|---------|
- | V1.0.0	        | Nov 2017     | Dec 2019    | Node 8       | Current |
+ | Module Version | Release Date | Minimum EOL | EOL With | Status          |
+ |----------------|--------------|-------------|----------|-----------------|
+ | V2.0.0         | May 2020     | Apr 2022    | Node 12  | Current         |
+ | V1.0.0         | Nov 2017     | Dec 2019    | Node 8   | End of life     |
 

--- a/lib/zosconnectee-connector.js
+++ b/lib/zosconnectee-connector.js
@@ -11,7 +11,6 @@ var RequestBuilder = require('loopback-connector-rest').RequestBuilder;
 var RestInitialize = require('loopback-connector-rest').initialize;
 var util = require('util');
 var fs = require('fs');
-var async = require('async');
 var Model = require('loopback').Model;
 var logger = require('../lib/logger');
 

--- a/lib/zosconnectee-connector.js
+++ b/lib/zosconnectee-connector.js
@@ -23,23 +23,23 @@ var logger = require('../lib/logger');
 exports.initialize = function initializeDataSource(dataSource, callback) {
   var settings = dataSource.settings;
 
-    // Get the template file
+  // Get the template file
   var templateFile = process.cwd() + '/server/' + settings.template;
   var templateJSON;
 
-    // check if the template file exists
+  // check if the template file exists
   try {
     fs.accessSync(templateFile, fs.F_OK);
-        // console.log('template file ' + templateFile + ' found.');
+    // console.log('template file ' + templateFile + ' found.');
 
     templateJSON = JSON.parse(
-            fs.readFileSync(
-                require('path').resolve(
-                    __dirname,
-                    templateFile),
-            'utf8'));
+      fs.readFileSync(
+        require('path').resolve(
+          __dirname,
+          templateFile),
+        'utf8'));
 
-        // console.log('done reading the template ' + JSON.stringify(templateJSON));
+    // console.log('done reading the template ' + JSON.stringify(templateJSON));
   } catch (e) {
     console.log('Unable to find the template file ' + process.cwd() + e);
   }
@@ -82,14 +82,14 @@ util.inherits(zosconnectee, RestConnector);
 zosconnectee.prototype.connect = function(callback) {
   var conn = this.settings;
 
-    // dummy - for debug purposes only
+  // dummy - for debug purposes only
   this._logger('connection is established');
 
   callback(null);
 };
 
 zosconnectee.prototype.disconnect = function(callback) {
-    // dummy - for debug purposes only
+  // dummy - for debug purposes only
   this._logger('connection is disconnected');
 
   callback(null);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "loopback-connector-zosconnectee",
-  "version": "1.0.1",
+  "version": "2.0.0-1",
   "description": "LoopBack Connector for z/OS Connect Enterprise Edition",
   "main": "index.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=10"
   },
   "scripts": {
     "test": "echo \"Done\"",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "async": "^1.5.2",
     "colors": "^1.1.2",
     "loopback-connector-rest": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "loopback-connector-rest": "^3.6.0"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^7.0.0",
     "eslint-config-loopback": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "colors": "^1.1.2",
-    "loopback-connector-rest": "^2.0.0"
+    "loopback-connector-rest": "^3.6.0"
   },
   "devDependencies": {
     "eslint": "^3.17.1",


### PR DESCRIPTION
- fix: remove unused dependency `async` 
- deps: upgrade `loopback-connector-rest` to `^3.6` to fix #7 
- chore: upgrade `eslint` to `^7.0` to fix vulnerability [WS-2018-0592](https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09)

There are not tests in this project so I hope this change is not going to break anything 🤞 